### PR TITLE
renaming enforce_private_link_endpoint_network_policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Type:
 
 ```hcl
 map(object({
-    cidr                                           = list(string)
-    service_endpoints                              = list(string)
-    enforce_private_link_endpoint_network_policies = bool
+    cidr                                      = list(string)
+    service_endpoints                         = list(string)
+    private_endpoint_network_policies_enabled = bool
     rules = map(object({
       priority                     = number,
       source_address_prefixes      = list(string),

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,10 @@ resource "azurerm_virtual_network" "virtual-network" {
 resource "azurerm_subnet" "subnet" {
   for_each = var.subnets
 
-  address_prefixes                               = each.value.cidr
-  name                                           = each.key
-  resource_group_name                            = var.resource_group
-  virtual_network_name                           = azurerm_virtual_network.virtual-network.name
-  service_endpoints                              = each.value.service_endpoints
-  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link_endpoint_network_policies
+  address_prefixes                          = each.value.cidr
+  name                                      = each.key
+  resource_group_name                       = var.resource_group
+  virtual_network_name                      = azurerm_virtual_network.virtual-network.name
+  service_endpoints                         = each.value.service_endpoints
+  private_endpoint_network_policies_enabled = each.value.private_endpoint_network_policies_enabled
 }

--- a/vars.tf
+++ b/vars.tf
@@ -31,9 +31,9 @@ variable "peering_remote_virtual_network_id" {
 
 variable "subnets" {
   type = map(object({
-    cidr                                           = list(string)
-    service_endpoints                              = list(string)
-    enforce_private_link_endpoint_network_policies = bool
+    cidr                                      = list(string)
+    service_endpoints                         = list(string)
+    private_endpoint_network_policies_enabled = bool
     rules = map(object({
       priority                     = number,
       source_address_prefixes      = list(string),


### PR DESCRIPTION
BREAKING CHANGE
feat: renaming enforce_private_link_endpoint_network_policies variable and subnet option due to upstream (azurerm provider) naming change