### PR TITLE
Fix breaking change for AzureRM 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ map(object({
       name    = string,
       actions = list(string),
     }))
-    private_endpoint_network_policies_enabled = bool
+    private_endpoint_network_policies = string
     rules = map(object({
       priority                     = number,
       source_address_prefixes      = list(string),

--- a/main.tf
+++ b/main.tf
@@ -25,5 +25,5 @@ resource "azurerm_subnet" "subnet" {
     }
   }
 
-  private_endpoint_network_policies_enabled = each.value.private_endpoint_network_policies_enabled
+  private_endpoint_network_policies = each.value.private_endpoint_network_policies
 }

--- a/vars.tf
+++ b/vars.tf
@@ -31,14 +31,14 @@ variable "peering_remote_virtual_network_id" {
 
 variable "subnets" {
   type = map(object({
-    cidr              = list(string)
-    service_endpoints = list(string)
+    cidr                = list(string)
+    service_endpoints   = list(string)
     service_delegations = map(object({
       name    = string,
       actions = list(string),
     }))
-    private_endpoint_network_policies_enabled = bool
-    rules = map(object({
+    private_endpoint_network_policies = string
+    rules                             = map(object({
       priority                     = number,
       source_address_prefixes      = list(string),
       source_port_ranges           = list(string),


### PR DESCRIPTION
feat: Compatibility with AzureRM 4

BREAKING CHANGE: private_endpoint_network_policies is now a string which can take the values Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled